### PR TITLE
Twitter handler - remove $ at the end of regex

### DIFF
--- a/src/angular-embed/handlers/twitter.js
+++ b/src/angular-embed/handlers/twitter.js
@@ -8,7 +8,7 @@
         return {
             name: 'Twitter',
             patterns: [
-                'https?://(?:www|mobile\\.)?twitter\\.com/(?:#!/)?[^/]+/status(?:es)?/(\\d+)/?$',
+                'https?://(?:www|mobile\\.)?twitter\\.com/(?:#!/)?[^/]+/status(?:es)?/(\\d+)/?',
                 'https?://t\\.co/[a-zA-Z0-9]+'
             ],
             embed: function(url) {


### PR DESCRIPTION
removal of $ at the end of regex to match twitter urls with params like https://twitter.com/hesselmann/status/940486978096762880?ref_src=twsrc%5Etfw